### PR TITLE
Fix errors and remove warnings

### DIFF
--- a/AmebaD/Package/hardware/libraries/BLE/src/BLECharacteristic.cpp
+++ b/AmebaD/Package/hardware/libraries/BLE/src/BLECharacteristic.cpp
@@ -371,7 +371,7 @@ uint8_t BLECharacteristic::generateAttrDescriptorDeclaration(T_ATTRIB_APPL* attr
         _desc_write_permissions |= GATT_PERM_WRITE_ENCRYPTED_REQ;
     }
     // Apply open permissions if no stricter permissions are found
-    if ((_char_attr_read_permissions == GATT_PERM_NONE) && (_char_attr_write_permissions == GATT_PERM_NONE)) {
+    if ((_desc_read_permissions == GATT_PERM_NONE) && (_desc_write_permissions == GATT_PERM_NONE)) {
         _desc_read_permissions |= GATT_PERM_READ;
         _desc_write_permissions |= GATT_PERM_WRITE;
     }
@@ -385,7 +385,7 @@ uint8_t BLECharacteristic::generateAttrDescriptorDeclaration(T_ATTRIB_APPL* attr
         attr_tbl[index].type_value[3] = HI_WORD(GATT_CLIENT_CHAR_CONFIG_DEFAULT);
         attr_tbl[index].value_len = 2;
         attr_tbl[index].p_value_context = NULL;
-        attr_tbl[index].permissions = (_desc_read_permissions | _desc_write_permissions);
+        attr_tbl[index].permissions = (GATT_PERM_READ | GATT_PERM_WRITE);
         index += 1;
     }
     if (_includeUserDescriptor) {

--- a/AmebaD/Package/hardware/libraries/BLE/src/BLEHIDDevice.cpp
+++ b/AmebaD/Package/hardware/libraries/BLE/src/BLEHIDDevice.cpp
@@ -18,9 +18,12 @@ uint8_t ble_hid_report_descriptor[] =
 };
 
 void HIDnotifCB (BLECharacteristic* chr, uint8_t connID, uint16_t cccd) {
+    (void) connID;
     if (chr->getUUID() == BLEUUID(REPORT_CHAR_UUID)) {
         uint8_t id = chr->getReportRefID();
         uint8_t type = chr->getReportRefType();
+        (void) id;
+        (void) type;
         if (cccd & GATT_CLIENT_CHAR_CONFIG_NOTIFY) {
             //printf("Notifications enabled on Characteristic %s ID %d Type %d for connection %d \n", chr->getUUID().str(), id, type, connID);
         } else {
@@ -36,9 +39,12 @@ void HIDnotifCB (BLECharacteristic* chr, uint8_t connID, uint16_t cccd) {
 }
 
 void HIDwriteCB (BLECharacteristic* chr, uint8_t connID) {
+    (void) connID;
     if (chr->getUUID() == BLEUUID(REPORT_CHAR_UUID)) {
         uint8_t id = chr->getReportRefID();
         uint8_t type = chr->getReportRefType();
+        (void) id;
+        (void) type;
         //printf("Data written on Characteristic %s ID %d Type %d for connection %d \n", chr->getUUID().str(), id, type, connID);
     } else {
         //printf("Data written on Characteristic %s for connection %d \n", chr->getUUID().str(), connID);
@@ -46,9 +52,12 @@ void HIDwriteCB (BLECharacteristic* chr, uint8_t connID) {
 }
 
 void HIDreadCB (BLECharacteristic* chr, uint8_t connID) {
+    (void) connID;
     if (chr->getUUID() == BLEUUID(REPORT_CHAR_UUID)) {
         uint8_t id = chr->getReportRefID();
         uint8_t type = chr->getReportRefType();
+        (void) id;
+        (void) type;
         //printf("Data read on Characteristic %s ID %d Type %d for connection %d \n", chr->getUUID().str(), id, type, connID);
     } else {
         //printf("Data read from Characteristic %s for connection %d \n", chr->getUUID().str(), connID);


### PR DESCRIPTION
Fix wrong attribute permissions for characteristic CCCD descriptor.
Remove unused variable warnings.